### PR TITLE
Place result of evaluating form at the end of form

### DIFF
--- a/litable.el
+++ b/litable.el
@@ -375,7 +375,10 @@ If depth = 0, also evaluate the current form and print the result."
                   (litable--print-input (cdr form) (point) 'font-lock-variable-name-face))))))))
     (when (and (= depth 0)
                (nth 1 (syntax-ppss)))
-      (let ((ostart (save-excursion (end-of-line) (point))))
+      (let ((ostart (save-excursion
+                      (litable-goto-toplevel-form)
+                      (forward-list)
+                      (point))))
         ;; TODO: make the face customizable
         (litable--print-result (eval form) ostart 'font-lock-warning-face)))))
 
@@ -469,12 +472,15 @@ I got tired of having to move outside the string to use it."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; updating the overlays
 
+(defun litable-goto-toplevel-form ()
+  (while (/= (car (syntax-ppss)) 0) (litable-backward-up-list)))
+
 (defun litable-update-defs (&optional a b c)
   (litable-remove-overlays)
   (when a
     (ignore-errors
       (let ((form (save-excursion
-                    (while (/= (car (syntax-ppss)) 0) (litable-backward-up-list))
+                    (litable-goto-toplevel-form)
                     (sexp-at-point))))
         (litable-find-function-subs-arguments form)))))
 


### PR DESCRIPTION
- instead of at the end of the current line
