### PR TITLE
Add ability to remove pure functions interactively

### DIFF
--- a/litable.el
+++ b/litable.el
@@ -564,7 +564,9 @@ using `completing-read', remove the selected candidate and save the list."
     (let ((symbol
            (completing-read "Pure function: "
                             litable-pure-functions-list
-                            nil t (symbol-name (litable--pure-at-point)))))
+                            nil t
+                            (if-let (sym-at-pt (litable--pure-at-point))
+                                (symbol-name sym-at-pt) nil))))
       (setq litable-pure-functions-list
             (delq (intern symbol) litable-pure-functions-list))
       (litable--save-lists))))

--- a/litable.el
+++ b/litable.el
@@ -545,6 +545,30 @@ With BATCH prefix argument, asks only once for all."
        (add-to-list 'litable-pure-functions-list cur))))
   (litable--save-lists))
 
+(defun litable--pure-at-point ()
+  "Return symbol at point if it's a pure function."
+  (let ((sym (symbol-at-point)))
+    (when (and
+           (functionp sym)
+           (-contains-p litable-pure-functions-list sym))
+      sym)))
+
+(defun litable-remove-from-pure-list ()
+  "Remove a function from the pure functions list.
+
+Provide completion for the content of `litable-pure-functions-list'
+using `completing-read', remove the selected candidate and save the list."
+  (interactive)
+  (if (null litable-pure-functions-list)
+      (message "No function trusted to be pure.")
+    (let ((symbol
+           (completing-read "Pure function: "
+                            litable-pure-functions-list
+                            nil t (symbol-name (litable--pure-at-point)))))
+      (setq litable-pure-functions-list
+            (delq (intern symbol) litable-pure-functions-list))
+      (litable--save-lists))))
+
 (defun litable--safe-eval (form)
   "Check if FORM contains only known pure functions and eval it.
 


### PR DESCRIPTION
As mentioned in #22 :

+ Add `litable--pure-at-point` which returns symbol at point if it is a pure function.

+ Add `litable-remove-from-pure-list` which either : 
    - uses the symbol at point if it's a pure function
    - prompts user for a function present in `litable-pure-functions-list`

If there's anything you'd like me to change, please let me know.